### PR TITLE
use Long to store max/minLength for string schema

### DIFF
--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -33,9 +33,9 @@ public class StringSchema extends Schema {
      */
     public static class Builder extends Schema.Builder<StringSchema> {
 
-        private Integer minLength;
+        private Long minLength;
 
-        private Integer maxLength;
+        private Long maxLength;
 
         private String pattern;
 
@@ -61,12 +61,12 @@ public class StringSchema extends Schema {
             return this;
         }
 
-        public Builder maxLength(final Integer maxLength) {
+        public Builder maxLength(final Long maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
-        public Builder minLength(final Integer minLength) {
+        public Builder minLength(final Long minLength) {
             this.minLength = minLength;
             return this;
         }
@@ -87,9 +87,9 @@ public class StringSchema extends Schema {
         return new Builder();
     }
 
-    private final Integer minLength;
+    private final Long minLength;
 
-    private final Integer maxLength;
+    private final Long maxLength;
 
     private final Pattern pattern;
 
@@ -119,11 +119,11 @@ public class StringSchema extends Schema {
         this.formatValidator = builder.formatValidator;
     }
 
-    public Integer getMaxLength() {
+    public Long getMaxLength() {
         return maxLength;
     }
 
-    public Integer getMinLength() {
+    public Long getMinLength() {
         return minLength;
     }
 
@@ -132,13 +132,13 @@ public class StringSchema extends Schema {
     }
 
     private List<ValidationException> testLength(final String subject) {
-        int actualLength = subject.codePointCount(0, subject.length());
+        Long actualLength = (long)subject.codePointCount(0, subject.length());
         List<ValidationException> rval = new ArrayList<>();
-        if (minLength != null && actualLength < minLength.intValue()) {
+        if (minLength != null && actualLength < minLength.longValue()) {
             rval.add(new ValidationException(this, "expected minLength: " + minLength + ", actual: "
                     + actualLength, "minLength"));
         }
-        if (maxLength != null && actualLength > maxLength.intValue()) {
+        if (maxLength != null && actualLength > maxLength.longValue()) {
             rval.add(new ValidationException(this, "expected maxLength: " + maxLength + ", actual: "
                     + actualLength, "maxLength"));
         }

--- a/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
@@ -20,16 +20,16 @@ public class StringSchemaLoader {
 
     public StringSchema.Builder load() {
         final StringSchema.Builder builder = StringSchema.builder();
-        ls.ifPresent("minLength", Integer.class, new Consumer<Integer>() {
+        ls.ifPresent("minLength", Number.class, new Consumer<Number>() {
             @Override
-            public void accept(Integer integer) {
-                builder.minLength(integer);
+            public void accept(Number number) {
+                builder.minLength(number.longValue());
             }
         });
-        ls.ifPresent("maxLength", Integer.class, new Consumer<Integer>() {
+        ls.ifPresent("maxLength", Number.class, new Consumer<Number>() {
             @Override
-            public void accept(Integer integer) {
-                builder.maxLength(integer);
+            public void accept(Number number) {
+                builder.maxLength(number.longValue());
             }
         });
         ls.ifPresent("pattern", String.class, new Consumer<String>() {

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -57,8 +57,8 @@ public class CombinedSchemaTest {
     @Test(expected = ValidationException.class)
     public void anyOfInvalid() {
         CombinedSchema.anyOf(Arrays.<Schema>asList(
-                StringSchema.builder().maxLength(2).build(),
-                StringSchema.builder().minLength(4).build()))
+                StringSchema.builder().maxLength((long)2).build(),
+                StringSchema.builder().minLength((long)4).build()))
                 .build().validate("foo");
     }
 

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -90,7 +90,7 @@ public class ObjectSchemaTest {
     @Test
     public void multipleSchemaDepViolation() {
         Schema billingAddressSchema = new StringSchema();
-        Schema billingNameSchema = StringSchema.builder().minLength(4).build();
+        Schema billingNameSchema = StringSchema.builder().minLength((long)4).build();
         ObjectSchema subject = ObjectSchema.builder()
                 .addPropertySchema("name", new StringSchema())
                 .addPropertySchema("credit_card", NumberSchema.builder().build())

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -56,7 +56,7 @@ public class StringSchemaTest {
 
     @Test
     public void maxLength() {
-        StringSchema subject = StringSchema.builder().maxLength(3).build();
+        StringSchema subject = StringSchema.builder().maxLength((long)3).build();
         TestSupport.failureOf(subject)
                 .expectedKeyword("maxLength")
                 .input("foobar")
@@ -65,7 +65,7 @@ public class StringSchemaTest {
 
     @Test
     public void minLength() {
-        StringSchema subject = StringSchema.builder().minLength(2).build();
+        StringSchema subject = StringSchema.builder().minLength((long)2).build();
         TestSupport.failureOf(subject)
                 .expectedKeyword("minLength")
                 .input("a")
@@ -75,7 +75,7 @@ public class StringSchemaTest {
     @Test
     public void multipleViolations() {
         try {
-            StringSchema.builder().minLength(3).maxLength(1).pattern("^b.*").build().validate("ab");
+            StringSchema.builder().minLength((long)3).maxLength((long)1).pattern("^b.*").build().validate("ab");
             Assert.fail();
         } catch (ValidationException e) {
             Assert.assertEquals(3, e.getCausingExceptions().size());


### PR DESCRIPTION
this library will presently regard a schema as invalid if the `maxLength` string schema property is a number larger than `Integer.MAX_VALUE` because the `maxLength` is stored as an Integer internally. This change makes it so that any `Number`[1] will be accepted for `minLength` and `maxLength`, and the string schema loader will build the schema using the `longValue` of that number. 

[1] this approach means that decimal values for `maxLength` would be accepted. E.g. `maxLength: 1.9` would result in a schema that was effectively the same as `maxLength: 1`. this is technically correct in terms of string length validation, but it means we might accept a schema that's not 100% in spec.

functional tested locally and unit tests are passing